### PR TITLE
READ_RANDOM support

### DIFF
--- a/scality_glance_store/store.py
+++ b/scality_glance_store/store.py
@@ -122,6 +122,17 @@ class Store(driver.Store):
         """
         Calculate range headers for partial object retrieval.
         """
+        def check_params(offset, chunk_size):
+            if chunk_size is not None:
+                if chunk_size <= 0:
+                    raise ValueError("'chunk_size' must be positive")
+                elif offset < 0:
+                    raise ValueError("'offset' may not be negative when "
+                                     "'chunk_size' is supplied")
+
+        # Validate input.
+        check_params(offset, chunk_size)
+
         # Obtain object size by a HEAD request. This is to ensure compatibiliy
         # with versions of sproxyd which has limited support for implicit
         # ranges in the HTTP Range header.
@@ -129,12 +140,6 @@ class Store(driver.Store):
 
         if chunk_size is not None:
             # Explicit range request.
-            if chunk_size <= 0:
-                raise ValueError("'chunk_size' must be positive")
-            elif offset < 0:
-                raise ValueError("'offset' may not be negative when "
-                                 "'chunk_size' is supplied")
-
             range_start = offset
             range_end = offset + chunk_size - 1
 

--- a/test/unit/test_store.py
+++ b/test/unit/test_store.py
@@ -122,7 +122,7 @@ class TestStore(glance_store.tests.base.StoreBaseTest):
 
         self.assertRaises(glance_store.exceptions.RemoteServiceUnavailable,
                           store.get, location)
-        mock_get_object.assert_called_once_with(image_id)
+        mock_get_object.assert_called_once_with(image_id, {})
 
     def test_get(self):
         store = Store(self.conf)
@@ -139,7 +139,7 @@ class TestStore(glance_store.tests.base.StoreBaseTest):
                 mock_get_object):
             resp, content_length = store.get(location)
 
-        mock_get_object.assert_called_once_with(image_id)
+        mock_get_object.assert_called_once_with(image_id, {})
         self.assertEqual(len(data), content_length)
         self.assertEqual(data, resp.another())
         self.assertEqual('', resp.another())


### PR DESCRIPTION
This adds support for the READ_RANDOM capability by leveraging HTTP range requests as outlined in #7. Due to limitations in sproxyd, explicit ranges must be calculated before a partial get request.

There are issues around how exceptions are handled in glance when requesting an object from the store. One of the paths calling the `store.get` is the `show` implementation in APIv1 https://github.com/openstack/glance/blob/master/glance/api/v1/images.py#L467. We can essentially only raise `RemoteServiceUnavailable`, `NotFound`, `StoreGetNotSupported`, `StoreRandomGetNotSupported` or `UnknownScheme`, none of which make much sense in case of an invalid request range, i.e. a 416 HTTP status code. A hackish way of doing this is to raise the webob exception immediately, which will fall through the glance exception logic in the `_get_from_store` method.
