### PR TITLE
Install requirements in a venv

### DIFF
--- a/jenkins/scality-glance-store-functional-tests/20-install-openstack.sh
+++ b/jenkins/scality-glance-store-functional-tests/20-install-openstack.sh
@@ -11,12 +11,11 @@ function common {
         sudo add-apt-repository --yes cloud-archive:icehouse
     fi
 
-    wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python -
-    sudo easy_install pip
-    sudo easy_install -U six
+    wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python -
+    sudo pip install -U six
 
     if is_centos; then
-        sudo yum install -y https://kojipkgs.fedoraproject.org//packages/python-mox/0.5.3/2.el6/noarch/python-mox-0.5.3-2.el6.noarch.rpm
+        sudo yum install -y ftp://ftp.is.co.za/mirror/fedora.redhat.com/epel/6/x86_64/python-mox-0.5.3-2.el6.noarch.rpm
     fi
 
     git clone -b ${DEVSTACK_BRANCH:-master} https://github.com/openstack-dev/devstack.git

--- a/jenkins/scality-glance-store-functional-tests/30-run-tests.sh
+++ b/jenkins/scality-glance-store-functional-tests/30-run-tests.sh
@@ -1,11 +1,22 @@
 #!/bin/bash -xue
 
 TEMPEST_DIR=/opt/stack/tempest
-sudo pip install -r $TEMPEST_DIR/test-requirements.txt -r $TEMPEST_DIR/requirements.txt 
-sudo pip install --upgrade nose
+
+virtualenv venv_for_nosetests
+set +o nounset # See https://github.com/pypa/virtualenv/issues/150
+source venv_for_nosetests/bin/activate
+set -o nounset
+
+pip install -r $TEMPEST_DIR/test-requirements.txt -r $TEMPEST_DIR/requirements.txt nose
+
 set +e
 nosetests -w $TEMPEST_DIR/tempest/api/image --exe --with-xunit --xunit-file=${WORKSPACE}/nosetests.xml
 set -e
+
+set +o nounset # See https://github.com/pypa/virtualenv/issues/150
+deactivate
+set -o nounset
+
 echo "Entering WORKSPACE."
 cd $WORKSPACE
 mkdir jenkins-logs


### PR DESCRIPTION
Otherwise newly installed requirements could conflict with OpenStack's
requirements.

Also, use a new URL to fetech python-mox on Centos 6, the old one 404'ed.
