### PR TITLE
Fix unit tests in test_store.py

### DIFF
--- a/test/unit/test_store.py
+++ b/test/unit/test_store.py
@@ -247,9 +247,9 @@ class TestStore(glance_store.tests.base.StoreBaseTest):
 
         # Assert the response has been read and the connection drained
         # and release
-        conn.getresponse.assert_called_oncewith()
-        conn.getresponse.read.assert_called_oncewith()
-        release_conn.assert_called_oncewith()
+        conn.getresponse.assert_called_once_with()
+        conn.getresponse().read.assert_called_once_with()
+        release_conn.assert_called_once_with()
 
         # Assert the return values of `store.add` are connect
         self.assertEqual('scality://%s' % image_id, img_uri)


### PR DESCRIPTION
A wrong assert call managed to get unnoticed for a while... Mock >=1.1
which was released 2 weeks ago highlighted this issue.
