### PR TITLE
Fix Tox job on Ubuntu 14

### DIFF
--- a/jenkins/scality-glance-store-tox/10-install-deps.sh
+++ b/jenkins/scality-glance-store-tox/10-install-deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xue
 
 function install_deb {
-    sudo aptitude install -y python-dev libffi-dev
+    sudo aptitude install -y python-dev libffi-dev gcc
 }
 
 function install_centos {


### PR DESCRIPTION
For several weeks, the tox job failed on Ubuntu 14 because somehow,
at some point, gcc stopped to be installed. Explicitely install gcc
on Ubuntu now.
