### PR TITLE
Lower our requirements on oslo.* versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 glance_store>=0.1.10
-oslo.config>=1.6.0 # Apache-2.0
-oslo.utils>=1.2.0 # Apache-2.0
+oslo.config>=1.2.0 # Apache-2.0
+oslo.utils>=1.0.0 # Apache-2.0
 git+https://github.com/scality/scality-sproxyd-client.git#egg=scality-sproxyd-client

--- a/scality_glance_store/store.py
+++ b/scality_glance_store/store.py
@@ -38,9 +38,21 @@ from glance_store import exceptions
 from glance_store.i18n import _, _LI, _LE
 from glance_store import location
 
-from oslo_config import cfg
-from oslo_utils import excutils
-from oslo_utils import units
+# For compability with OpenStack Glance Store Juno
+# which requires glance_store>=0.1.10. Glance_store 0.1.10
+# requires oslo.config>=1.2.0 which only provides olso.config
+try:
+    from oslo_config import cfg
+except ImportError:
+    from oslo.config import cfg
+try:
+    from oslo_utils import excutils
+except ImportError:
+    from oslo.utils import excutils
+try:
+    from oslo_utils import units
+except ImportError:
+    from oslo.utils import units
 
 import scality_sproxyd_client.exceptions
 from scality_sproxyd_client import sproxyd_client

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,8 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2.7'],
-    install_requires=['glance_store>=0.1.10', 'oslo.config>=1.6.0',
-                      'oslo.utils>=1.2.0', 'scality-sproxyd-client'],
+    install_requires=['glance_store>=0.1.10', 'oslo.config>=1.2.0',
+                      'oslo.utils>=1.0.0', 'scality-sproxyd-client'],
     entry_points={
         'glance_store.drivers': [
             'scality=scality_glance_store.store:Store',


### PR DESCRIPTION
We currently requires glance_store>=0.1.10 so we should not expect
a more recent version of oslo.config and oslo.utils than what
glance_store>=0.1.10 requires (see [1])

This issue (us being to demanding) was seen at a customer which
installation is based on RDO Juno.

[1] https://github.com/openstack/glance_store/blob/0.1.10/requirements.txt
