### PR TITLE
Revert "Revert "CI: Hack - Apply Python2.6 patch locally""

### DIFF
--- a/jenkins/scality-glance-store-functional-tests/30-run-tests.sh
+++ b/jenkins/scality-glance-store-functional-tests/30-run-tests.sh
@@ -1,6 +1,12 @@
 #!/bin/bash -xue
 
 cd /opt/stack/tempest
+
+echo "*** Hack: Apply https://review.openstack.org/#/c/252837/"
+curl "https://review.openstack.org/gitweb?p=openstack/tempest.git;a=patch;h=660b440f12c607d720e59e1c6ab297c2c28b1ea3" | git am
+
+git log -n2
+
 set +e
 tox -e all -- tempest.api.image
 RC=$?


### PR DESCRIPTION
This reverts commit 6d47ef8867c7127cabdd74d2e6d1054320a96794.

We now apply a different patch than the original one because a new
Py26-invalid line crept in.
