### PR TITLE
store.add(): a new kwargs was added.

### DIFF
--- a/scality_glance_store/store.py
+++ b/scality_glance_store/store.py
@@ -156,7 +156,8 @@ class Store(driver.Store):
                 content_length)
 
     @capabilities_check
-    def add(self, image_id, image_file, image_size, context=None):
+    def add(self, image_id, image_file, image_size, context=None,
+            verifier=None):
         """
         Stores an image file with supplied identifier to the backend
         storage system and returns a tuple containing information
@@ -165,6 +166,7 @@ class Store(driver.Store):
         :param image_id: The opaque image identifier
         :param image_file: The image data to write, as a file-like object
         :param image_size: The size of the image data to write, in bytes
+        :param verifier: An object used to verify signatures for images
 
         :retval tuple of URL in backing store, bytes written, and checksum
         :raises `glance_store.exceptions.Duplicate` if the image already
@@ -202,6 +204,10 @@ class Store(driver.Store):
                 actual_image_size += chunk_length
                 conn.send('%x\r\n%s\r\n' % (chunk_length, chunk))
                 checksum.update(chunk)
+
+                if verifier:
+                    verifier.update(chunk)
+
             conn.send('0\r\n\r\n')
             resp = conn.getresponse()
         except Exception:

--- a/test/unit/test_store.py
+++ b/test/unit/test_store.py
@@ -235,15 +235,20 @@ class TestStore(glance_store.tests.base.StoreBaseTest):
         file_contents = "chunk00000remainder"
         image_file = StringIO.StringIO(file_contents)
 
+        verifier = mock.Mock()
+
         store = Store(self.conf)
         img_uri, img_size, img_checksum, _ = store.add(image_id, image_file,
-                                                       None)
+                                                       None, verifier=verifier)
 
         # Assert data has been written to Sproxyd
         calls = [mock.call('%x\r\n%s\r\n' % (len(file_contents),
                                              file_contents)),
                  mock.call('0\r\n\r\n')]
         conn.send.assert_has_calls(calls)
+
+        # Assert that the crypto verifier has been called
+        verifier.update.assert_called_once_with(file_contents)
 
         # Assert the response has been read and the connection drained
         # and release


### PR DESCRIPTION
Commit [1](https://github.com/openstack/glance_store/commit/819c7f9a927393d4549461c9b0183a23ce174f6f) in glance_store added a new kwarg argument to the `add`
method of the drivers. We need to update our driver.

This got unoticed so far because the global-requirements in OpenStack
capped glance-store to 0.10.0. This commit [2](https://github.com/openstack/requirements/commit/00d671a46548cba9ef77a46971120649e25f5bbf) bumped the global-requirement
which reveiled our incompatibility.
